### PR TITLE
Detect wider class of array types

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -120,12 +120,12 @@ function detect_sol_array_type(sol::Union{SciMLBase.AbstractDiffEqArray, SciMLBa
 
     if arraytype <: CuArray 
         return true 
-    elseif arraytype <: Array 
+    elseif arraytype <: AbstractArray 
         return false 
     elseif arraytype <: Number 
         if typeof(sol.u) <: CuArray 
             return true 
-        elseif typeof(sol.u) <: Array 
+        elseif typeof(sol.u) <: AbstractArray 
             return false 
         else 
             error("Can't determine array type of solution")


### PR DESCRIPTION
The function `detect_sol_array_type` is restricted to `Array` and `CuArray` types, which means there is no default behavior implemented. By detecting all `AbstractArray` types as CPU arrays, a default behavior is given. This is especially important when using e.g. `StaticArrays` for low-dimensional problems. 